### PR TITLE
feat: exports updated to enable loading of custom SQLite extensions

### DIFF
--- a/lib/sqlite3_async.dart
+++ b/lib/sqlite3_async.dart
@@ -8,7 +8,7 @@ import 'package:logging/logging.dart';
 import 'package:logging_appenders/logging_appenders.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-export 'package:sqlite3/sqlite3.dart' show AllowedArgumentCount;
+export 'package:sqlite3/sqlite3.dart' show AllowedArgumentCount, sqlite3, SqliteExtension;
 
 /// An opened sqlite3 database with async methods.
 class AsyncDatabase {


### PR DESCRIPTION
`sqlite3` and `SqliteExtension` references are exported from the underlying package to enable loading custom native SQLite extensions in the following way:  

```
sqlite3.ensureExtensionLoaded(
  SqliteExtension.inLibrary(someext.lib, 'sqlite3_someext_init'),
);
```